### PR TITLE
Ffl withlists

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -1581,23 +1581,23 @@ def _field_gen(filename, read_data_bytes):
     pp_file_seek = pp_file.seek
     pp_file_read = pp_file.read
 
+    header_longs_format = '>{:d}i'.format(NUM_LONG_HEADERS)
+    header_floats_format = '>{:d}f'.format(NUM_FLOAT_HEADERS)
     # Keep reading until we reach the end of file
     while True:
         # Move past the leading header length word
         pp_file_seek(PP_WORD_DEPTH, os.SEEK_CUR)
         # Get the LONG header entries
-#        header_longs = np.fromfile(pp_file, dtype='>i%d' % PP_WORD_DEPTH, count=NUM_LONG_HEADERS)
         data_longs = pp_file_read(PP_WORD_DEPTH * NUM_LONG_HEADERS)
         # Nothing returned => EOF
         if len(data_longs) == 0:
             break
-        header_longs = struct.unpack_from('>' + 'i' * NUM_LONG_HEADERS, data_longs)
+        header_longs = struct.unpack_from(header_longs_format, data_longs)
         # Get the FLOAT header entries
-#        header_floats = np.fromfile(pp_file, dtype='>f%d' % PP_WORD_DEPTH, count=NUM_FLOAT_HEADERS)
         data_floats = pp_file_read(PP_WORD_DEPTH * NUM_FLOAT_HEADERS)
         if len(data_floats) == 0:
             break
-        header_floats = struct.unpack_from('>' + 'f' * NUM_FLOAT_HEADERS, data_floats)
+        header_floats = struct.unpack_from(header_floats_format, data_floats)
 
         # Make a PPField of the appropriate sub-class (depends on header release number)
         pp_field = make_pp_field(header_longs, header_floats)


### PR DESCRIPTION
I don't seriously expect you to incorporate this.
But check this out, with the following speed compare :

```
itpp@eld238: /net/home/h05/itpp/git/iris/iris_main > ../../tehuti/tehuti.py fastpp ffl_withlists wl_fast_field_loading
Loading cache from /home/h05/itpp/.local/share/tehuti/fastpp.json
timeit-fast_load_pp
    2.63138508797 -> 7.60107111931 (289%)
```

But **WARNING** lots of  tests now get slightly different floating-point values, which messes up a lot of stuff...
E.G.

```
======================================================================
FAIL: test_full_file (iris.tests.test_pp_module.TestPPField_GlobalTemperature)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/h05/itpp/git/iris/iris_main/lib/iris/tests/test_pp_module.py", line 164, in test_full_file
    self.check_pp(self.r[0:10], ('PP', 'global_test.pp.txt'))
  File "/home/h05/itpp/git/iris/iris_main/lib/iris/tests/test_pp_module.py", line 89, in check_pp
    self._assert_str_same(reference+'\n', test_string+'\n', reference_filename, type_comparison_name='PP files')
  File "/home/h05/itpp/git/iris/iris_main/lib/iris/tests/__init__.py", line 161, in _assert_str_same
    self.fail("%s do not match: %s\n%s" % (type_comparison_name, reference_filename, diff))
AssertionError: PP files do not match: ('PP', 'global_test.pp.txt')
--- Reference
+++ Test result
@@ -48,5 +48,5 @@
-   bzy: 92.5
-   bdy: -2.5
-   bzx: -3.75
-   bdx: 3.75
-   bmdi: -1e+30
+   bzy: 92.4999847412
+   bdy: -2.49999904633
+   bzx: -3.74999904633
+   bdx: 3.74999904633
+   bmdi: -1.00000001505e+30
```
