### PR TITLE
MAINT: Removed agg backend hardcoded path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,6 @@ setup(
                 'lib/iris/experimental/_agg_raster.cpp',
             ],
             include_dirs=['./lib/iris/experimental',
-                '/data/local/itwl/third_party_builds/matplotlib-1.3.1/agg24/include',
                 np.get_include()
                 ],
             language='c++',

--- a/setup.py
+++ b/setup.py
@@ -237,9 +237,7 @@ setup(
                 'lib/iris/experimental/_agg.pyx',
                 'lib/iris/experimental/_agg_raster.cpp',
             ],
-            include_dirs=['./lib/iris/experimental',
-                np.get_include()
-                ],
+            include_dirs=['./lib/iris/experimental', np.get_include()],
             language='c++',
         ),
     ],


### PR DESCRIPTION
Had to remove the unnecessary hard-coded path to the include dir. of 'agg'.  We can simply pass the include path in when building as follows:

python2.7 setup.py --with-unpack build_ext \
-I/opt/ukmo/share/include /path/to/agg/include \
-L/opt/ukmo/share/lib \
-R/opt/ukmo/share/lib \
--inplace
