### PR TITLE
Pp fix  datadtypefillvalue

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1774,7 +1774,8 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
             self._numpy_array = None
         else:
             self._numpy_array = value
-            self._dask_array = value
+            self._dask_array = None
+
         # Cancel any 'realisation' datatype conversion, and fill value.
         self._dtype = None
         self.fill_value = None

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1359,7 +1359,6 @@ class Test_data_dtype_fillvalue(tests.IrisTest):
         self.assertEqual(cube.core_data.dtype, np.dtype('f4'))
         self.assertIsNone(cube.fill_value)
 
-
     def test_lazydata_maskedints_dtype_change(self):
         # Check that re-assigning dtype resets fill_value.
         cube = self._sample_cube(dtype=np.int16, masked=True, lazy=True,

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1383,6 +1383,31 @@ class Test_data_dtype_fillvalue(tests.IrisTest):
         self.assertEqual(cube.fill_value.dtype, np.dtype('i2'))
         self.assertArrayAllClose(cube.fill_value, 1735)
 
+    def test_set_fill_value(self):
+        cube = self._sample_cube()
+        cube.fill_value = -74.6
+        self.assertEqual(cube.fill_value.dtype, np.dtype('f4'))
+        self.assertArrayAllClose(cube.fill_value, -74.6)
+
+    def test_set_fill_value__typecast(self):
+        cube = self._sample_cube(dtype=np.int16)
+        cube.fill_value = -74.6
+        self.assertEqual(cube.fill_value.dtype, np.dtype('i2'))
+        self.assertArrayAllClose(cube.fill_value, -75)
+
+    def test_set_fill_value__casterror(self):
+        cube = self._sample_cube(dtype=np.int16)
+        msg = "invalid for cube dtype\('int16'\)"
+        with self.assertRaisesRegexp(ValueError, msg):
+            # NOTE: this doesn't actually work properly in most cases.
+            # E.G. it will happily assign 1e12 to an int16 and gets 4096.
+            cube.fill_value = -1.0e23
+
+    def test_clear_fill_value(self):
+        cube = self._sample_cube(cube_fill_value=123.768)
+        cube.fill_value = None
+        self.assertIsNone(cube.fill_value)
+
 
 class TestSubset(tests.IrisTest):
     def test_scalar_coordinate(self):


### PR DESCRIPTION
Here's my take on how to fix the outstanding API tests.
Of course, it does also break another 38 CML tests....

I've also added some extra tests for the fill-value API, which I had sort-of missed previously.