### PR TITLE
Keep cube's fill_value when resetting the cube's data in interpolation test

### DIFF
--- a/lib/iris/tests/test_interpolation.py
+++ b/lib/iris/tests/test_interpolation.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -26,7 +26,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import iris.tests as tests
 
 import numpy as np
-import numpy.ma as ma
 from scipy.interpolate import interp1d
 
 import iris
@@ -43,7 +42,9 @@ def normalise_order(cube):
     #     function when the circular flag is true.
     #   * scipy.interpolate.interp1d in 0.11.0 which is used in
     #     `Linear1dExtrapolator`.
+    cube_fill_val = cube.fill_value
     cube.data = np.ascontiguousarray(cube.data)
+    cube.fill_value = cube_fill_val
 
 
 class TestLinearExtrapolator(tests.IrisTest):


### PR DESCRIPTION
In [a test](https://github.com/SciTools/iris/blob/dask/lib/iris/tests/test_interpolation.py#L528) for the deprecated function `iris.analysis._interpolate_private.linear` a cube with lazy unmasked pp data is interpolated. After the interpolation the fill value is kept, but the test then passes the cube through `normalise_order` which resets the cube's data thereby losing the fill value.

I have not done anything to `dtype` as cube._dtype is always None throughout the test.